### PR TITLE
Fix project_group in appdata file

### DIFF
--- a/in/appdata.xml
+++ b/in/appdata.xml
@@ -26,7 +26,7 @@
     <icon height="64" width="64" type="cached">64x64/com.endlessm.myths.en.png</icon>
 
     <url type="homepage">https://endlessm.com</url>
-    <project_group>GNOME</project_group>
+    <project_group>Endless</project_group>
 
   </component>
 


### PR DESCRIPTION
Anything based off this template is an Endless project, not a GNOME project.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T12884